### PR TITLE
Added timeout information to xhr response fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ module.exports = function smallxhr(url, data, callback, method, contenttype, tim
 
 	requestTimeout = setTimeout(function() {
 		xhr.abort();
+    xhr.status = '408';
+    xhr.responseText = 'Network timeout exceeded';
     callback(new Error("smallxhr: aborted by a timeout"), null, xhr);
 	}, timeout || 5000);
 


### PR DESCRIPTION
When an XHR request times out it's useful to produce an xhr response
message and a 408 http code for better error handling.
